### PR TITLE
fix: KVクリーンアップをバックグラウンド実行に変更して起動タイムアウトを回避

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,13 +39,17 @@ if (import.meta.main) {
 
   console.log("Server starting on http://localhost:8000");
 
-  // デプロイ時の1回限りのタスク（必要に応じてコメントアウトまたは削除してください）
-  try {
-    const { cleanup } = await import("../scripts/cleanup_kv.ts");
-    await cleanup();
-  } catch (error) {
-    console.error("Failed to run cleanup task:", error);
-  }
+  // デプロイ時の1回限りのタスク（タイムアウト回避のためバックグラウンドで実行）
+  Deno.cron("One-time KV Cleanup", "*/1 * * * *", async () => {
+    try {
+      console.log("⏳ Starting background KV cleanup...");
+      const { cleanup } = await import("../scripts/cleanup_kv.ts");
+      await cleanup();
+      console.log("✨ Background KV cleanup complete!");
+    } catch (error) {
+      console.error("❌ Failed to run background cleanup task:", error);
+    }
+  });
 
   await serve(app.fetch, { port: 8000 });
 


### PR DESCRIPTION
## 概要
サーバー起動時に実行していたKVのクリーンアップ処理がタイムアウトを引き起こし、起動に失敗（またはログが停止）する問題を修正しました。

## 修正内容
- **バックグラウンド実行化**: `src/index.ts` で直接 `await cleanup()` していた処理を `Deno.cron` に移動しました。
- **メリット**: 
    - サーバーが即座に起動し、外部からのリクエスト（Healthcheck等）に応答できるようになります。
    - クリーンアップ処理はバックグラウンドで実行されるため、処理件数が多くても起動タイムアウトに影響しません。

## 確認事項
- [ ] デプロイ後、サーバーが正常に起動すること
- [ ] 1分以内に `⏳ Starting background KV cleanup...` ログが出力されること
